### PR TITLE
Fix typo in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
 - The limits will be between 0 and 90 and should be translated to the range acceptable by the gun.
-- Do not forget to active subscribtion verification to allow firing
+- Do not forget to active subscription verification to allow firing


### PR DESCRIPTION
## Summary
- fix 'subscription' spelling in TODO list

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'nerf_gun_control')*

------
https://chatgpt.com/codex/tasks/task_e_6840ba14863083329af009e3302d1487