### PR TITLE
Use correct parameter name

### DIFF
--- a/nerf-gun-control/nerf_controller.py
+++ b/nerf-gun-control/nerf_controller.py
@@ -10,7 +10,7 @@ class NerfController:
 
     def fire(self, x=0, y=0, shot=1, wait=True):
         url = f"{self.server_url}/nerf"
-        params = {"x": x, "y": y, "shots": shot}
+        params = {"x": x, "y": y, "shot": shot}
         try:
             response = requests.get(url, params=params)
             response.raise_for_status()


### PR DESCRIPTION
## Summary
- use `shot` key when building fire request params

## Testing
- `pytest nerf-gun-control/test_nerf_controller.py -q`
- `pytest nerf-gun-control/test/test_nerf_controller_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840baf320048332ab3f6a9627e64f31