### PR TITLE
Update tests for new controller API

### DIFF
--- a/nerf-gun-control/test_nerf_controller.py
+++ b/nerf-gun-control/test_nerf_controller.py
@@ -1,28 +1,38 @@
+import os
+import sys
 import pytest
 from unittest.mock import patch, Mock
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from nerf_controller import NerfController
 
 @pytest.fixture
 def nerf_controller():
     return NerfController("http://test-server.com")
 
+@patch('nerf_controller.NerfController.wait_until_idle')
 @patch('nerf_controller.requests.get')
-def test_fire_success(mock_get, nerf_controller):
+def test_fire_success(mock_get, mock_wait, nerf_controller):
     mock_response = Mock()
-    mock_response.text = "Nerf activated: x=10, y=20, shot=3"
+    mock_response.json.return_value = {"message": "shots:3"}
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
+    mock_wait.return_value = (True, {"status": "idle", "shots": 3})
 
-    result = nerf_controller.fire(x=10, y=20, shot=3)
-    assert result == "Nerf activated: x=10, y=20, shot=3"
+    success, data = nerf_controller.fire(x=10, y=20, shot=3)
+
+    assert success is True
+    assert data == {"status": "idle", "shots": 3}
     mock_get.assert_called_once_with("http://test-server.com/nerf", params={'x': 10, 'y': 20, 'shot': 3})
+    mock_wait.assert_called_once_with(shots=3)
 
 @patch('nerf_controller.requests.get')
 def test_fire_error(mock_get, nerf_controller):
     mock_get.side_effect = Exception("Connection error")
 
-    result = nerf_controller.fire(x=10, y=20, shot=3)
-    assert result.find("Error:") > -1
+    success, data = nerf_controller.fire(x=10, y=20, shot=3)
+    assert success is False
+    assert data == {"status": "error", "message": "Connection error", "shots": 0}
 
 @patch('nerf_controller.requests.get')
 def test_stop_success(mock_get, nerf_controller):
@@ -61,16 +71,18 @@ def test_wait_until_idle_success(mock_get_status, nerf_controller):
         {"status": "idle"}
     ]
 
-    result = nerf_controller.wait_until_idle(timeout=5, check_interval=0.1)
-    assert result == True
+    success, status = nerf_controller.wait_until_idle(timeout=5, check_interval=0.1)
+    assert success is True
+    assert status["status"] == "idle"
     assert mock_get_status.call_count == 3
 
 @patch('nerf_controller.NerfController.get_status')
 def test_wait_until_idle_timeout(mock_get_status, nerf_controller):
     mock_get_status.return_value = {"status": "busy"}
 
-    result = nerf_controller.wait_until_idle(timeout=0.5, check_interval=0.1)
-    assert result == False
+    success, status = nerf_controller.wait_until_idle(timeout=0.5, check_interval=0.1)
+    assert success is False
+    assert status["status"] == "busy"
     assert mock_get_status.call_count > 1
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update test files to reflect new `(success, data)` return format from `fire`
- skip integration suite unless `RUN_INTEGRATION_TESTS=1` is set
- ensure tests import the controller module correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bc471ea083329caaab3ed7c1191f